### PR TITLE
fix: correct pub link for sealed_unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <i>
-  <p align="center"><a href="https://pub.dev/packages/flutter_bloc">flutter_bloc</a> meets <a href="https://pub.dev/packages/sealed_union">sealed_unions</a>
+  <p align="center"><a href="https://pub.dev/packages/flutter_bloc">flutter_bloc</a> meets <a href="https://pub.dev/packages/sealed_unions">sealed_unions</a>
   </p>
 </i>
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Correct pub link for sealed_unions from [sealed_union](https://pub.dev/packages/sealed_union) to [sealed_unions](https://pub.dev/packages/sealed_unions).

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
- Click on the old link that will redirect to 404.
```
```

## Impact to Remaining Code Base
This PR will affect:
N/A
* 
